### PR TITLE
Fix exception for 'load' on jQuery 1.8 and above

### DIFF
--- a/script.js
+++ b/script.js
@@ -7,7 +7,7 @@
 /* DOKUWIKI:include taboverride.js */
 /* DOKUWIKI:include taboverride.escape.js */
 
-jQuery(window).load(function(){
+jQuery(window).on('load', function(){
         var textareas = document.getElementsByTagName('textarea');
         tabOverride.set(textareas).tabSize(0).autoIndent(true).escape(true);
 });


### PR DESCRIPTION
The 'load' event has been deprecated for a couple of years, and thus broke the plugin.